### PR TITLE
list before rps

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -6,6 +6,6 @@ import rps from './rock-paper-scissors'
 export default [
   coin,
   dice,
-  rps,
-  list
+  list,
+  rps
 ]


### PR DESCRIPTION
Currently list isn't above the fold in the inline-UI and as rps is probably the least often used I would bump that to the bottom
Just a matter of UX though